### PR TITLE
Product Sync 20201021

### DIFF
--- a/products.json
+++ b/products.json
@@ -5,7 +5,7 @@
     "products": [
       {
         "pid": 1,
-        "name": "Original 1000",
+        "name": "LIFX Original 1000",
         "features": {
           "color": true,
           "chain": false,
@@ -20,7 +20,7 @@
       },
       {
         "pid": 3,
-        "name": "Color 650",
+        "name": "LIFX Color 650",
         "features": {
           "color": true,
           "chain": false,
@@ -35,7 +35,7 @@
       },
       {
         "pid": 10,
-        "name": "White 800 (Low Voltage)",
+        "name": "LIFX White 800 (Low Voltage)",
         "features": {
           "color": false,
           "chain": false,
@@ -50,7 +50,7 @@
       },
       {
         "pid": 11,
-        "name": "White 800 (High Voltage)",
+        "name": "LIFX White 800 (High Voltage)",
         "features": {
           "color": false,
           "chain": false,
@@ -60,12 +60,27 @@
           "temperature_range": [
             2700,
             6500
+          ]
+        }
+      },
+      {
+        "pid": 15,
+        "name": "LIFX Color 1000",
+        "features": {
+          "color": true,
+          "chain": false,
+          "matrix": false,
+          "infrared": false,
+          "multizone": false,
+          "temperature_range": [
+            2500,
+            9000
           ]
         }
       },
       {
         "pid": 18,
-        "name": "White 900 BR30 (Low Voltage)",
+        "name": "LIFX White 900 BR30 (Low Voltage)",
         "features": {
           "color": false,
           "chain": false,
@@ -73,14 +88,29 @@
           "infrared": false,
           "multizone": false,
           "temperature_range": [
-            2700,
-            6500
+            2500,
+            9000
+          ]
+        }
+      },
+      {
+        "pid": 19,
+        "name": "LIFX White 900 BR30 (High Voltage)",
+        "features": {
+          "color": false,
+          "chain": false,
+          "matrix": false,
+          "infrared": false,
+          "multizone": false,
+          "temperature_range": [
+            2500,
+            9000
           ]
         }
       },
       {
         "pid": 20,
-        "name": "Color 1000 BR30",
+        "name": "LIFX Color 1000 BR30",
         "features": {
           "color": true,
           "chain": false,
@@ -95,7 +125,7 @@
       },
       {
         "pid": 22,
-        "name": "Color 1000",
+        "name": "LIFX Color 1000",
         "features": {
           "color": true,
           "chain": false,
@@ -140,7 +170,7 @@
       },
       {
         "pid": 29,
-        "name": "LIFX+ A19",
+        "name": "LIFX A19 Night Vision",
         "features": {
           "color": true,
           "chain": false,
@@ -155,7 +185,7 @@
       },
       {
         "pid": 30,
-        "name": "LIFX+ BR30",
+        "name": "LIFX BR30 Night Vision",
         "features": {
           "color": true,
           "chain": false,
@@ -185,7 +215,7 @@
       },
       {
         "pid": 32,
-        "name": "LIFX Z 2",
+        "name": "LIFX Z",
         "features": {
           "color": true,
           "chain": false,
@@ -254,6 +284,36 @@
         }
       },
       {
+        "pid": 39,
+        "name": "LIFX Downlight White To Warm",
+        "features": {
+          "color": false,
+          "chain": false,
+          "matrix": false,
+          "infrared": false,
+          "multizone": false,
+          "temperature_range": [
+            1500,
+            9000
+          ]
+        }
+      },
+      {
+        "pid": 40,
+        "name": "LIFX Downlight",
+        "features": {
+          "color": true,
+          "chain": false,
+          "matrix": false,
+          "infrared": false,
+          "multizone": false,
+          "temperature_range": [
+            2500,
+            9000
+          ]
+        }
+      },
+      {
         "pid": 43,
         "name": "LIFX A19",
         "features": {
@@ -285,7 +345,7 @@
       },
       {
         "pid": 45,
-        "name": "LIFX+ A19",
+        "name": "LIFX A19 Night Vision",
         "features": {
           "color": true,
           "chain": false,
@@ -300,7 +360,7 @@
       },
       {
         "pid": 46,
-        "name": "LIFX+ BR30",
+        "name": "LIFX BR30 Night Vision",
         "features": {
           "color": true,
           "chain": false,
@@ -315,7 +375,7 @@
       },
       {
         "pid": 49,
-        "name": "LIFX Mini",
+        "name": "LIFX Mini Color",
         "features": {
           "color": true,
           "chain": false,
@@ -330,7 +390,7 @@
       },
       {
         "pid": 50,
-        "name": "LIFX Mini Warm to White",
+        "name": "LIFX Mini White To Warm",
         "features": {
           "color": false,
           "chain": false,
@@ -360,6 +420,21 @@
       },
       {
         "pid": 52,
+        "name": "LIFX GU10",
+        "features": {
+          "color": true,
+          "chain": false,
+          "matrix": false,
+          "infrared": false,
+          "multizone": false,
+          "temperature_range": [
+            2500,
+            9000
+          ]
+        }
+      },
+      {
+        "pid": 53,
         "name": "LIFX GU10",
         "features": {
           "color": true,
@@ -420,7 +495,7 @@
       },
       {
         "pid": 60,
-        "name": "LIFX Mini Warm to White",
+        "name": "LIFX Mini White To Warm",
         "features": {
           "color": false,
           "chain": false,
@@ -480,7 +555,7 @@
       },
       {
         "pid": 64,
-        "name": "LIFX+ A19",
+        "name": "LIFX A19 Night Vision",
         "features": {
           "color": true,
           "chain": false,
@@ -495,7 +570,7 @@
       },
       {
         "pid": 65,
-        "name": "LIFX+ BR30",
+        "name": "LIFX BR30 Night Vision",
         "features": {
           "color": true,
           "chain": false,
@@ -509,10 +584,25 @@
         }
       },
       {
+        "pid": 66,
+        "name": "LIFX Mini White",
+        "features": {
+          "color": false,
+          "chain": false,
+          "matrix": false,
+          "infrared": false,
+          "multizone": false,
+          "temperature_range": [
+            2700,
+            2700
+          ]
+        }
+      },
+      {
         "pid": 68,
         "name": "LIFX Candle",
         "features": {
-          "color": true,
+          "color": false,
           "chain": false,
           "matrix": true,
           "infrared": false,
@@ -524,8 +614,21 @@
         }
       },
       {
+        "pid": 70,
+        "name": "LIFX Switch",
+        "features": {
+          "color": false,
+          "relays": true,
+          "chain": false,
+          "matrix": false,
+          "buttons": true,
+          "infrared": false,
+          "multizone": false
+        }
+      },
+      {
         "pid": 81,
-        "name": "LIFX Candle Warm to White",
+        "name": "LIFX Candle White To Warm",
         "features": {
           "color": false,
           "chain": false,
@@ -540,7 +643,22 @@
       },
       {
         "pid": 82,
-        "name": "LIFX Filament",
+        "name": "LIFX Filament Clear",
+        "features": {
+          "color": false,
+          "chain": false,
+          "matrix": false,
+          "infrared": false,
+          "multizone": false,
+          "temperature_range": [
+            2100,
+            2100
+          ]
+        }
+      },
+      {
+        "pid": 85,
+        "name": "LIFX Filament Amber",
         "features": {
           "color": false,
           "chain": false,
@@ -550,6 +668,246 @@
           "temperature_range": [
             2000,
             2000
+          ]
+        }
+      },
+      {
+        "pid": 87,
+        "name": "LIFX Mini White",
+        "features": {
+          "color": false,
+          "chain": false,
+          "matrix": false,
+          "infrared": false,
+          "multizone": false,
+          "temperature_range": [
+            2700,
+            2700
+          ]
+        }
+      },
+      {
+        "pid": 88,
+        "name": "LIFX Mini White",
+        "features": {
+          "color": false,
+          "chain": false,
+          "matrix": false,
+          "infrared": false,
+          "multizone": false,
+          "temperature_range": [
+            2700,
+            2700
+          ]
+        }
+      },
+      {
+        "pid": 89,
+        "name": "LIFX Switch",
+        "features": {
+          "color": false,
+          "relays": true,
+          "chain": false,
+          "matrix": false,
+          "buttons": true,
+          "infrared": false,
+          "multizone": false
+        }
+      },
+      {
+        "pid": 90,
+        "name": "LIFX Clean",
+        "features": {
+          "hev": true,
+          "color": true,
+          "chain": false,
+          "matrix": false,
+          "infrared": false,
+          "multizone": false,
+          "temperature_range": [
+            2500,
+            9000
+          ]
+        }
+      },
+      {
+        "pid": 91,
+        "name": "LIFX Color",
+        "features": {
+          "color": true,
+          "chain": false,
+          "matrix": false,
+          "infrared": false,
+          "multizone": false,
+          "temperature_range": [
+            2500,
+            9000
+          ]
+        }
+      },
+      {
+        "pid": 92,
+        "name": "LIFX Color",
+        "features": {
+          "color": true,
+          "chain": false,
+          "matrix": false,
+          "infrared": false,
+          "multizone": false,
+          "temperature_range": [
+            2500,
+            9000
+          ]
+        }
+      },
+      {
+        "pid": 94,
+        "name": "LIFX BR30",
+        "features": {
+          "color": true,
+          "chain": false,
+          "matrix": false,
+          "infrared": false,
+          "multizone": false,
+          "temperature_range": [
+            2500,
+            9000
+          ]
+        }
+      },
+      {
+        "pid": 96,
+        "name": "LIFX Candle White To Warm",
+        "features": {
+          "color": false,
+          "chain": false,
+          "matrix": false,
+          "infrared": false,
+          "multizone": false,
+          "temperature_range": [
+            2200,
+            6500
+          ]
+        }
+      },
+      {
+        "pid": 97,
+        "name": "LIFX A19",
+        "features": {
+          "color": true,
+          "chain": false,
+          "matrix": false,
+          "infrared": false,
+          "multizone": false,
+          "temperature_range": [
+            2500,
+            9000
+          ]
+        }
+      },
+      {
+        "pid": 98,
+        "name": "LIFX BR30",
+        "features": {
+          "color": true,
+          "chain": false,
+          "matrix": false,
+          "infrared": false,
+          "multizone": false,
+          "temperature_range": [
+            2500,
+            9000
+          ]
+        }
+      },
+      {
+        "pid": 99,
+        "name": "LIFX Clean",
+        "features": {
+          "hev": true,
+          "color": true,
+          "chain": false,
+          "matrix": false,
+          "infrared": false,
+          "multizone": false,
+          "temperature_range": [
+            2500,
+            9000
+          ]
+        }
+      },
+      {
+        "pid": 100,
+        "name": "LIFX Filament Clear",
+        "features": {
+          "color": false,
+          "chain": false,
+          "matrix": false,
+          "infrared": false,
+          "multizone": false,
+          "temperature_range": [
+            2100,
+            2100
+          ]
+        }
+      },
+      {
+        "pid": 101,
+        "name": "LIFX Filament Amber",
+        "features": {
+          "color": false,
+          "chain": false,
+          "matrix": false,
+          "infrared": false,
+          "multizone": false,
+          "temperature_range": [
+            2000,
+            2000
+          ]
+        }
+      },
+      {
+        "pid": 109,
+        "name": "LIFX A19 Night Vision",
+        "features": {
+          "color": true,
+          "chain": false,
+          "matrix": false,
+          "infrared": true,
+          "multizone": false,
+          "temperature_range": [
+            2500,
+            9000
+          ]
+        }
+      },
+      {
+        "pid": 110,
+        "name": "LIFX BR30 Night Vision",
+        "features": {
+          "color": true,
+          "chain": false,
+          "matrix": false,
+          "infrared": true,
+          "multizone": false,
+          "temperature_range": [
+            2500,
+            9000
+          ]
+        }
+      },
+      {
+        "pid": 111,
+        "name": "LIFX A19 Night Vision",
+        "features": {
+          "color": true,
+          "chain": false,
+          "matrix": false,
+          "infrared": true,
+          "multizone": false,
+          "temperature_range": [
+            2500,
+            9000
           ]
         }
       }

--- a/products.json
+++ b/products.json
@@ -1,444 +1,558 @@
 [
-	{
-		"vid": 1,
-		"name": "LIFX",
-		"products": [
-			{
-				"pid": 1,
-				"name": "Original 1000",
-				"features": {
-					"color": true,
-					"infrared": false,
-					"matrix": false,
-					"multizone": false,
-					"temperature_range": [2500, 9000],
-					"chain": false
-				}
-			},
-			{
-				"pid": 3,
-				"name": "Color 650",
-				"features": {
-					"color": true,
-					"infrared": false,
-					"matrix": false,
-					"multizone": false,
-					"temperature_range": [2500, 9000],
-					"chain": false
-				}
-			},
-			{
-				"pid": 10,
-				"name": "White 800 (Low Voltage)",
-				"features": {
-					"color": false,
-					"infrared": false,
-					"matrix": false,
-					"multizone": false,
-					"temperature_range": [2700, 6500],
-					"chain": false
-				}
-			},
-			{
-				"pid": 11,
-				"name": "White 800 (High Voltage)",
-				"features": {
-					"color": false,
-					"infrared": false,
-					"matrix": false,
-					"multizone": false,
-					"temperature_range": [2700, 6500],
-					"chain": false
-				}
-			},
-			{
-				"pid": 18,
-				"name": "White 900 BR30 (Low Voltage)",
-				"features": {
-					"color": false,
-					"infrared": false,
-					"matrix": false,
-					"multizone": false,
-					"temperature_range": [2700, 6500],
-					"chain": false
-				}
-			},
-			{
-				"pid": 20,
-				"name": "Color 1000 BR30",
-				"features": {
-					"color": true,
-					"infrared": false,
-					"matrix": false,
-					"multizone": false,
-					"temperature_range": [2500, 9000],
-					"chain": false
-				}
-			},
-			{
-				"pid": 22,
-				"name": "Color 1000",
-				"features": {
-					"color": true,
-					"infrared": false,
-					"matrix": false,
-					"multizone": false,
-					"temperature_range": [2500, 9000],
-					"chain": false
-				}
-			},
-			{
-				"pid": 27,
-				"name": "LIFX A19",
-				"features": {
-					"color": true,
-					"infrared": false,
-					"matrix": false,
-					"multizone": false,
-					"temperature_range": [2500, 9000],
-					"chain": false
-				}
-			},
-			{
-				"pid": 28,
-				"name": "LIFX BR30",
-				"features": {
-					"color": true,
-					"infrared": false,
-					"matrix": false,
-					"multizone": false,
-					"temperature_range": [2500, 9000],
-					"chain": false
-				}
-			},
-			{
-				"pid": 29,
-				"name": "LIFX+ A19",
-				"features": {
-					"color": true,
-					"infrared": true,
-					"matrix": false,
-					"multizone": false,
-					"temperature_range": [2500, 9000],
-					"chain": false
-				}
-			},
-			{
-				"pid": 30,
-				"name": "LIFX+ BR30",
-				"features": {
-					"color": true,
-					"infrared": true,
-					"matrix": false,
-					"multizone": false,
-					"temperature_range": [2500, 9000],
-					"chain": false
-				}
-			},
-			{
-				"pid": 31,
-				"name": "LIFX Z",
-				"features": {
-					"color": true,
-					"infrared": false,
-					"matrix": false,
-					"multizone": true,
-					"temperature_range": [2500, 9000],
-					"chain": false
-				}
-			},
-			{
-				"pid": 32,
-				"name": "LIFX Z 2",
-				"features": {
-					"color": true,
-					"infrared": false,
-					"matrix": false,
-					"multizone": true,
-					"temperature_range": [2500, 9000],
-					"chain": false,
-					"min_ext_mz_firmware": 1532997580,
-					"min_ext_mz_firmware_components": [2, 77]
-				}
-			},
-			{
-				"pid": 36,
-				"name": "LIFX Downlight",
-				"features": {
-					"color": true,
-					"infrared": false,
-					"matrix": false,
-					"multizone": false,
-					"temperature_range": [2500, 9000],
-					"chain": false
-				}
-			},
-			{
-				"pid": 37,
-				"name": "LIFX Downlight",
-				"features": {
-					"color": true,
-					"infrared": false,
-					"matrix": false,
-					"multizone": false,
-					"temperature_range": [2500, 9000],
-					"chain": false
-				}
-			},
-			{
-				"pid": 38,
-				"name": "LIFX Beam",
-				"features": {
-					"color": true,
-					"infrared": false,
-					"matrix": false,
-					"multizone": true,
-					"temperature_range": [2500, 9000],
-					"chain": false,
-					"min_ext_mz_firmware": 1532997580,
-					"min_ext_mz_firmware_components": [2, 77]
-				}
-			},
-			{
-				"pid": 43,
-				"name": "LIFX A19",
-				"features": {
-					"color": true,
-					"infrared": false,
-					"matrix": false,
-					"multizone": false,
-					"temperature_range": [2500, 9000],
-					"chain": false
-				}
-			},
-			{
-				"pid": 44,
-				"name": "LIFX BR30",
-				"features": {
-					"color": true,
-					"infrared": false,
-					"matrix": false,
-					"multizone": false,
-					"temperature_range": [2500, 9000],
-					"chain": false
-				}
-			},
-			{
-				"pid": 45,
-				"name": "LIFX+ A19",
-				"features": {
-					"color": true,
-					"infrared": true,
-					"matrix": false,
-					"multizone": false,
-					"temperature_range": [2500, 9000],
-					"chain": false
-				}
-			},
-			{
-				"pid": 46,
-				"name": "LIFX+ BR30",
-				"features": {
-					"color": true,
-					"infrared": true,
-					"matrix": false,
-					"multizone": false,
-					"temperature_range": [2500, 9000],
-					"chain": false
-				}
-			},
-			{
-				"pid": 49,
-				"name": "LIFX Mini",
-				"features": {
-					"color": true,
-					"infrared": false,
-					"matrix": false,
-					"multizone": false,
-					"temperature_range": [2500, 9000],
-					"chain": false
-				}
-			},
-			{
-				"pid": 50,
-				"name": "LIFX Mini Warm to White",
-				"features": {
-					"color": false,
-					"infrared": false,
-					"matrix": false,
-					"multizone": false,
-					"temperature_range": [1500, 4000],
-					"chain": false
-				}
-			},
-			{
-				"pid": 51,
-				"name": "LIFX Mini White",
-				"features": {
-					"color": false,
-					"infrared": false,
-					"matrix": false,
-					"multizone": false,
-					"temperature_range": [2700, 2700],
-					"chain": false
-				}
-			},
-			{
-				"pid": 52,
-				"name": "LIFX GU10",
-				"features": {
-					"color": true,
-					"infrared": false,
-					"matrix": false,
-					"multizone": false,
-					"temperature_range": [2500, 9000],
-					"chain": false
-				}
-			},
-			{
-				"pid": 55,
-				"name": "LIFX Tile",
-				"features": {
-					"color": true,
-					"infrared": false,
-					"matrix": true,
-					"multizone": false,
-					"temperature_range": [2500, 9000],
-					"chain": true
-				}
-			},
-			{
-				"pid": 57,
-				"name": "LIFX Candle",
-				"features": {
-					"color": true,
-					"infrared": false,
-					"matrix": true,
-					"multizone": false,
-					"temperature_range": [1500, 9000],
-					"chain": false
-				}
-			},
-			{
-				"pid": 59,
-				"name": "LIFX Mini Color",
-				"features": {
-					"color": true,
-					"infrared": false,
-					"matrix": false,
-					"multizone": false,
-					"temperature_range": [2500, 9000],
-					"chain": false
-				}
-			},
-			{
-				"pid": 60,
-				"name": "LIFX Mini Warm to White",
-				"features": {
-					"color": false,
-					"infrared": false,
-					"matrix": false,
-					"multizone": false,
-					"temperature_range": [1500, 4000],
-					"chain": false
-				}
-			},
-			{
-				"pid": 61,
-				"name": "LIFX Mini White",
-				"features": {
-					"color": false,
-					"infrared": false,
-					"matrix": false,
-					"multizone": false,
-					"temperature_range": [2700, 2700],
-					"chain": false
-				}
-			},
-			{
-				"pid": 62,
-				"name": "LIFX A19",
-				"features": {
-					"color": true,
-					"infrared": false,
-					"matrix": false,
-					"multizone": false,
-					"temperature_range": [2500, 9000],
-					"chain": false
-				}
-			},
-			{
-				"pid": 63,
-				"name": "LIFX BR30",
-				"features": {
-					"color": true,
-					"infrared": false,
-					"matrix": false,
-					"multizone": false,
-					"temperature_range": [2500, 9000],
-					"chain": false
-				}
-			},
-			{
-				"pid": 64,
-				"name": "LIFX+ A19",
-				"features": {
-					"color": true,
-					"infrared": true,
-					"matrix": false,
-					"multizone": false,
-					"temperature_range": [2500, 9000],
-					"chain": false
-				}
-			},
-			{
-				"pid": 65,
-				"name": "LIFX+ BR30",
-				"features": {
-					"color": true,
-					"infrared": true,
-					"matrix": false,
-					"multizone": false,
-					"temperature_range": [2500, 9000],
-					"chain": false
-				}
-			},
-			{
-				"pid": 68,
-				"name": "LIFX Candle",
-				"features": {
-					"color": true,
-					"infrared": false,
-					"matrix": true,
-					"multizone": false,
-					"temperature_range": [1500, 9000],
-					"chain": false
-				}
-			},
-			{
-				"pid": 81,
-				"name": "LIFX Candle Warm to White",
-				"features": {
-					"color": false,
-					"infrared": false,
-					"matrix": false,
-					"multizone": false,
-					"temperature_range": [2200, 6500],
-					"chain": false
-				}
-			},
-			{
-				"pid": 82,
-				"name": "LIFX Filament",
-				"features": {
-					"color": false,
-					"infrared": false,
-					"matrix": false,
-					"multizone": false,
-					"temperature_range": [2000, 2000],
-					"chain": false
-				}
-			}
-		]
-	}
+  {
+    "vid": 1,
+    "name": "LIFX",
+    "products": [
+      {
+        "pid": 1,
+        "name": "Original 1000",
+        "features": {
+          "color": true,
+          "chain": false,
+          "matrix": false,
+          "infrared": false,
+          "multizone": false,
+          "temperature_range": [
+            2500,
+            9000
+          ]
+        }
+      },
+      {
+        "pid": 3,
+        "name": "Color 650",
+        "features": {
+          "color": true,
+          "chain": false,
+          "matrix": false,
+          "infrared": false,
+          "multizone": false,
+          "temperature_range": [
+            2500,
+            9000
+          ]
+        }
+      },
+      {
+        "pid": 10,
+        "name": "White 800 (Low Voltage)",
+        "features": {
+          "color": false,
+          "chain": false,
+          "matrix": false,
+          "infrared": false,
+          "multizone": false,
+          "temperature_range": [
+            2700,
+            6500
+          ]
+        }
+      },
+      {
+        "pid": 11,
+        "name": "White 800 (High Voltage)",
+        "features": {
+          "color": false,
+          "chain": false,
+          "matrix": false,
+          "infrared": false,
+          "multizone": false,
+          "temperature_range": [
+            2700,
+            6500
+          ]
+        }
+      },
+      {
+        "pid": 18,
+        "name": "White 900 BR30 (Low Voltage)",
+        "features": {
+          "color": false,
+          "chain": false,
+          "matrix": false,
+          "infrared": false,
+          "multizone": false,
+          "temperature_range": [
+            2700,
+            6500
+          ]
+        }
+      },
+      {
+        "pid": 20,
+        "name": "Color 1000 BR30",
+        "features": {
+          "color": true,
+          "chain": false,
+          "matrix": false,
+          "infrared": false,
+          "multizone": false,
+          "temperature_range": [
+            2500,
+            9000
+          ]
+        }
+      },
+      {
+        "pid": 22,
+        "name": "Color 1000",
+        "features": {
+          "color": true,
+          "chain": false,
+          "matrix": false,
+          "infrared": false,
+          "multizone": false,
+          "temperature_range": [
+            2500,
+            9000
+          ]
+        }
+      },
+      {
+        "pid": 27,
+        "name": "LIFX A19",
+        "features": {
+          "color": true,
+          "chain": false,
+          "matrix": false,
+          "infrared": false,
+          "multizone": false,
+          "temperature_range": [
+            2500,
+            9000
+          ]
+        }
+      },
+      {
+        "pid": 28,
+        "name": "LIFX BR30",
+        "features": {
+          "color": true,
+          "chain": false,
+          "matrix": false,
+          "infrared": false,
+          "multizone": false,
+          "temperature_range": [
+            2500,
+            9000
+          ]
+        }
+      },
+      {
+        "pid": 29,
+        "name": "LIFX+ A19",
+        "features": {
+          "color": true,
+          "chain": false,
+          "matrix": false,
+          "infrared": true,
+          "multizone": false,
+          "temperature_range": [
+            2500,
+            9000
+          ]
+        }
+      },
+      {
+        "pid": 30,
+        "name": "LIFX+ BR30",
+        "features": {
+          "color": true,
+          "chain": false,
+          "matrix": false,
+          "infrared": true,
+          "multizone": false,
+          "temperature_range": [
+            2500,
+            9000
+          ]
+        }
+      },
+      {
+        "pid": 31,
+        "name": "LIFX Z",
+        "features": {
+          "color": true,
+          "chain": false,
+          "matrix": false,
+          "infrared": false,
+          "multizone": true,
+          "temperature_range": [
+            2500,
+            9000
+          ]
+        }
+      },
+      {
+        "pid": 32,
+        "name": "LIFX Z 2",
+        "features": {
+          "color": true,
+          "chain": false,
+          "matrix": false,
+          "infrared": false,
+          "multizone": true,
+          "temperature_range": [
+            2500,
+            9000
+          ],
+          "min_ext_mz_firmware": 1532997580,
+          "min_ext_mz_firmware_components": [
+            2,
+            77
+          ]
+        }
+      },
+      {
+        "pid": 36,
+        "name": "LIFX Downlight",
+        "features": {
+          "color": true,
+          "chain": false,
+          "matrix": false,
+          "infrared": false,
+          "multizone": false,
+          "temperature_range": [
+            2500,
+            9000
+          ]
+        }
+      },
+      {
+        "pid": 37,
+        "name": "LIFX Downlight",
+        "features": {
+          "color": true,
+          "chain": false,
+          "matrix": false,
+          "infrared": false,
+          "multizone": false,
+          "temperature_range": [
+            2500,
+            9000
+          ]
+        }
+      },
+      {
+        "pid": 38,
+        "name": "LIFX Beam",
+        "features": {
+          "color": true,
+          "chain": false,
+          "matrix": false,
+          "infrared": false,
+          "multizone": true,
+          "temperature_range": [
+            2500,
+            9000
+          ],
+          "min_ext_mz_firmware": 1532997580,
+          "min_ext_mz_firmware_components": [
+            2,
+            77
+          ]
+        }
+      },
+      {
+        "pid": 43,
+        "name": "LIFX A19",
+        "features": {
+          "color": true,
+          "chain": false,
+          "matrix": false,
+          "infrared": false,
+          "multizone": false,
+          "temperature_range": [
+            2500,
+            9000
+          ]
+        }
+      },
+      {
+        "pid": 44,
+        "name": "LIFX BR30",
+        "features": {
+          "color": true,
+          "chain": false,
+          "matrix": false,
+          "infrared": false,
+          "multizone": false,
+          "temperature_range": [
+            2500,
+            9000
+          ]
+        }
+      },
+      {
+        "pid": 45,
+        "name": "LIFX+ A19",
+        "features": {
+          "color": true,
+          "chain": false,
+          "matrix": false,
+          "infrared": true,
+          "multizone": false,
+          "temperature_range": [
+            2500,
+            9000
+          ]
+        }
+      },
+      {
+        "pid": 46,
+        "name": "LIFX+ BR30",
+        "features": {
+          "color": true,
+          "chain": false,
+          "matrix": false,
+          "infrared": true,
+          "multizone": false,
+          "temperature_range": [
+            2500,
+            9000
+          ]
+        }
+      },
+      {
+        "pid": 49,
+        "name": "LIFX Mini",
+        "features": {
+          "color": true,
+          "chain": false,
+          "matrix": false,
+          "infrared": false,
+          "multizone": false,
+          "temperature_range": [
+            2500,
+            9000
+          ]
+        }
+      },
+      {
+        "pid": 50,
+        "name": "LIFX Mini Warm to White",
+        "features": {
+          "color": false,
+          "chain": false,
+          "matrix": false,
+          "infrared": false,
+          "multizone": false,
+          "temperature_range": [
+            1500,
+            4000
+          ]
+        }
+      },
+      {
+        "pid": 51,
+        "name": "LIFX Mini White",
+        "features": {
+          "color": false,
+          "chain": false,
+          "matrix": false,
+          "infrared": false,
+          "multizone": false,
+          "temperature_range": [
+            2700,
+            2700
+          ]
+        }
+      },
+      {
+        "pid": 52,
+        "name": "LIFX GU10",
+        "features": {
+          "color": true,
+          "chain": false,
+          "matrix": false,
+          "infrared": false,
+          "multizone": false,
+          "temperature_range": [
+            2500,
+            9000
+          ]
+        }
+      },
+      {
+        "pid": 55,
+        "name": "LIFX Tile",
+        "features": {
+          "color": true,
+          "chain": true,
+          "matrix": true,
+          "infrared": false,
+          "multizone": false,
+          "temperature_range": [
+            2500,
+            9000
+          ]
+        }
+      },
+      {
+        "pid": 57,
+        "name": "LIFX Candle",
+        "features": {
+          "color": true,
+          "chain": false,
+          "matrix": true,
+          "infrared": false,
+          "multizone": false,
+          "temperature_range": [
+            1500,
+            9000
+          ]
+        }
+      },
+      {
+        "pid": 59,
+        "name": "LIFX Mini Color",
+        "features": {
+          "color": true,
+          "chain": false,
+          "matrix": false,
+          "infrared": false,
+          "multizone": false,
+          "temperature_range": [
+            2500,
+            9000
+          ]
+        }
+      },
+      {
+        "pid": 60,
+        "name": "LIFX Mini Warm to White",
+        "features": {
+          "color": false,
+          "chain": false,
+          "matrix": false,
+          "infrared": false,
+          "multizone": false,
+          "temperature_range": [
+            1500,
+            4000
+          ]
+        }
+      },
+      {
+        "pid": 61,
+        "name": "LIFX Mini White",
+        "features": {
+          "color": false,
+          "chain": false,
+          "matrix": false,
+          "infrared": false,
+          "multizone": false,
+          "temperature_range": [
+            2700,
+            2700
+          ]
+        }
+      },
+      {
+        "pid": 62,
+        "name": "LIFX A19",
+        "features": {
+          "color": true,
+          "chain": false,
+          "matrix": false,
+          "infrared": false,
+          "multizone": false,
+          "temperature_range": [
+            2500,
+            9000
+          ]
+        }
+      },
+      {
+        "pid": 63,
+        "name": "LIFX BR30",
+        "features": {
+          "color": true,
+          "chain": false,
+          "matrix": false,
+          "infrared": false,
+          "multizone": false,
+          "temperature_range": [
+            2500,
+            9000
+          ]
+        }
+      },
+      {
+        "pid": 64,
+        "name": "LIFX+ A19",
+        "features": {
+          "color": true,
+          "chain": false,
+          "matrix": false,
+          "infrared": true,
+          "multizone": false,
+          "temperature_range": [
+            2500,
+            9000
+          ]
+        }
+      },
+      {
+        "pid": 65,
+        "name": "LIFX+ BR30",
+        "features": {
+          "color": true,
+          "chain": false,
+          "matrix": false,
+          "infrared": true,
+          "multizone": false,
+          "temperature_range": [
+            2500,
+            9000
+          ]
+        }
+      },
+      {
+        "pid": 68,
+        "name": "LIFX Candle",
+        "features": {
+          "color": true,
+          "chain": false,
+          "matrix": true,
+          "infrared": false,
+          "multizone": false,
+          "temperature_range": [
+            1500,
+            9000
+          ]
+        }
+      },
+      {
+        "pid": 81,
+        "name": "LIFX Candle Warm to White",
+        "features": {
+          "color": false,
+          "chain": false,
+          "matrix": false,
+          "infrared": false,
+          "multizone": false,
+          "temperature_range": [
+            2200,
+            6500
+          ]
+        }
+      },
+      {
+        "pid": 82,
+        "name": "LIFX Filament",
+        "features": {
+          "color": false,
+          "chain": false,
+          "matrix": false,
+          "infrared": false,
+          "multizone": false,
+          "temperature_range": [
+            2000,
+            2000
+          ]
+        }
+      }
+    ]
+  }
 ]


### PR DESCRIPTION
Fixes https://github.com/LIFX/products/issues/9 and https://github.com/LIFX/products/issues/7

I have sync'd this repository with devices that we have out or are about to be released and also updated some names of our products.

* the LIFX+ range is now the Night Vision range
* I have added a couple old products that should have been here already
* [Downlight](https://www.lifx.com.au/products/lifx-downlight-colour)
* [GU10](https://www.lifx.com.au/products/gu10-colour)
* Some more variations of A19/BR30/Mini products
* Candle White to Warm
* [Clean](https://www.lifx.com.au/pages/lifx-clean)
* [Filament](https://www.lifx.com.au/products/lifx-filament)
* [Switch](https://www.lifx.com.au/products/lifx-switch)

Added new properties

* `relays` and `buttons` for the [Switch](https://www.lifx.com.au/products/lifx-switch)
* `hev` says this device has High Energy visible light LEDs (the [Clean](https://www.lifx.com.au/pages/lifx-clean))

Note that there are two commits here. The first one changes the formatting without changing the structure so that the second commit is a meaningful diff.