### PR TITLE
[sync] Correct some of the kelvin ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,11 @@ LAN Protocol. LiFi Labs, Inc. © 2021. All rights reserved. Usage of this docume
 * `multizone` = The light supports a 1D linear array of LEDs (the Z and Beam)
 * `temperature_range` = An array of the minimum and maximum kelvin values this
   device supports. If the numbers are the same then the device does not support
-  variable kelvin values. It is `null` for devices that don't have LEDs (the
-  LIFX Switch)
+  variable kelvin values. It is `null` for devices that aren't lighting
+  products (the LIFX Switch)
 * `extended_multizone` = The more capable `extended` API for multizone control
+  that lets us control all the zones on the device with a single message instead
+  of many.
 
 ### Determining capabilities
 
@@ -55,9 +57,9 @@ def get_capabilities(vid, pid, major, minor):
 
             cap.update(product["features"])
 
-            for ma, mi, other in product["upgrades"]:
-                if (major, minor) >= (ma, mi):
-                    cap.update(other)
+            for upgrade in product["upgrades"]:
+                if (upgrade["major"], upgrade["minor"]) >= (ma, mi):
+                    cap.update(upgrade["features"])
 
             return cap
 ```

--- a/README.md
+++ b/README.md
@@ -4,33 +4,112 @@
 
 ## Terms and Conditions
 
-LAN Protocol. LiFi Labs, Inc. © 2015. All rights reserved. Usage of this documentation is bound by the [LIFX Developer Terms](http://www.lifx.com/pages/developer-terms-of-use).
+LAN Protocol. LiFi Labs, Inc. © 2021. All rights reserved. Usage of this documentation is bound by the [LIFX Developer Terms](http://www.lifx.com/pages/developer-terms-of-use).
 
-### Extended multizone
+### Available capabilities
 
-Multizone products like the LIFX Z and the LIFX Beam have an "Extended Multizone"
-api when you have new enough firmware. The version of firmware that enables this
-feature is specified by the `min_ext_mz_firmware` and
-`min_ext_mz_firmware_components` fields for a multizone product in products.json
+* `color` = The light changes physical appearance when the Hue value is changed
+* `chain` = The light may be connected to physically separated hardware
+  (currently only the LIFX Tile)
+* `matrix` = The light supports a 2D matrix of LEDs (the Tile and Candle)
+* `relays` = The device has relays for controlling physical power to something
+  (the LIFX Switch)
+* `buttons` = The device has physical buttons to press (the LIFX Switch)
+* `infrared` = The light supports emitting infrared light
+* `multizone` = The light supports a 1D linear array of LEDs (the Z and Beam)
+* `temperature_range` = An array of the minimum and maximum kelvin values this
+  device supports. If the numbers are the same then the device does not support
+  variable kelvin values. It is `null` for devices that don't have LEDs (the
+  LIFX Switch)
+* `extended_multizone` = The more capable `extended` API for multizone control
+
+### Determining capabilities
+
+To determine the capabilities of a device you need four values from the device:
+
+* `vendor_id`, this will likely be `1` which says it's a LIFX device
+* `product_id`, this has a different number per product
+* `firmware_major`, the major revision number for the firmware
+* `firmware_minor`, the minor revision number for the firmware
+
+You can get the first two numbers via the `GetVersion` message, and the second
+two via the `GetHostFirmware` message.
+
+So for example, if I had a candle on `(3, 60)` firmware I'd have
+`vid:1 pid:57 major:3 minor:60`.
+
+We can then create a dictionary of capabilities from the json using code that
+looks like this.
+
+```python
+def get_capabilities(vid, pid, major, minor):
+    for by_vendor in products:
+        if by_vendor["vid"] != vid:
+            continue
+
+        cap = by_vendor["default"]
+
+        for product in by_vendor["products"]:
+            if product["pid"] != pid:
+                continue
+
+            cap.update(product["features"])
+
+            for ma, mi, other in product["upgrades"]:
+                if (major, minor) >= (ma, mi):
+                    cap.update(other)
+
+            return cap
+```
+
+Note that this method will replace the need to look for `min_ext_mz_firmware` and
+`min_ext_mz_firmware_components` as it is replaced with the `extended_multizone`
+capability that becomes true after a new enough firmware.
+
+### Firmware Major/Minor
+
+Some functionality in devices exists only after certain firmware versions and so
+it can be necessary to look the firmware on the device to determine if that device
+can do particular things.
+
+LIFX firmware is identified by a pair of numbers, referred to as the `major` and
+`minor` versions. For example, `(3, 60)` or `(2, 80)`.
+
+The `major` component will stay consistent over time for different generations of
+our hardware, whilst the `minor` component is incremented.
 
 These fields refers to the response from a GetHostFirmware packet to your device.
-If you interpret the StateHostFirmware packet with `version_major` and
-`version_minor` then use the `min_ext_mz_firmware_components` field to make sure
-the firmware is new enough. If your StateHostFirmware packet sees just one Uint32
-for the version then do the following code to get major and minor and then
-also use `min_ext_mz_firmware_components`.
+Our public protocol has these two components as separate fields in the packet
+description, but there was a time when it was described using one `Uint32`.
+
+For libraries that have this, you may use the following code to split that number:
 
 ```
 major = version >> 0x10
 minor = version & 0xFFFF
 ```
 
-Alternatively you may compare the build timestamp on the StateHostFirmware against
-`min_ext_mz_firmware`, but we don't recommend this is as it is a more brittle
-comparison.
-
-The comparison logic may look like:
+Once you have your two components, you can compare a desired pair with your
+retrieved pair with something like:
 
 ```
-desired_major, desired_minor = min_ext_mz_firmware_components
-has_extended = device_major >= desired_major and device_minor >= desired_minor
+has_capability = device_major >= desired_major and device_minor >= desired_minor
+```
+
+In Python, you can compare two tuples for the same affect:
+
+```
+has_capability = (device_major, device_minor) >= (desired_major, desired_minor)
+```
+
+Determining Extended Multizone
+------------------------------
+
+Before changes made in February 2021 that describes the process above, we had
+two fields to determine if a device has new enough firmware to support our
+`extended multizone` messages. These were `min_ext_mz_firmware_components` and
+`min_ext_mz_firmware`.
+
+If you are working with a version of the `products.json` that does not contain
+the `upgrades` structure, you may use `min_ext_mz_firmware` as the `(major, minor)`
+pair for comparison and safely ignore `min_ext_mz_firmware`.

--- a/products.json
+++ b/products.json
@@ -6,8 +6,8 @@
       "color": false,
       "chain": false,
       "matrix": false,
-      "relays": true,
-      "buttons": true,
+      "relays": false,
+      "buttons": false,
       "infrared": false,
       "multizone": false,
       "temperature_range": null,
@@ -173,16 +173,16 @@
           ]
         },
         "upgrades": [
-          [
-            2,
-            80,
-            {
+          {
+            "major": 2,
+            "minor": 80,
+            "features": {
               "temperature_range": [
                 1500,
                 9000
               ]
             }
-          ]
+          }
         ]
       },
       {
@@ -200,16 +200,16 @@
           ]
         },
         "upgrades": [
-          [
-            2,
-            80,
-            {
+          {
+            "major": 2,
+            "minor": 80,
+            "features": {
               "temperature_range": [
                 1500,
                 9000
               ]
             }
-          ]
+          }
         ]
       },
       {
@@ -227,16 +227,16 @@
           ]
         },
         "upgrades": [
-          [
-            2,
-            80,
-            {
+          {
+            "major": 2,
+            "minor": 80,
+            "features": {
               "temperature_range": [
                 1500,
                 9000
               ]
             }
-          ]
+          }
         ]
       },
       {
@@ -254,16 +254,16 @@
           ]
         },
         "upgrades": [
-          [
-            2,
-            80,
-            {
+          {
+            "major": 2,
+            "minor": 80,
+            "features": {
               "temperature_range": [
                 1500,
                 9000
               ]
             }
-          ]
+          }
         ]
       },
       {
@@ -302,23 +302,23 @@
           ]
         },
         "upgrades": [
-          [
-            2,
-            77,
-            {
+          {
+            "major": 2,
+            "minor": 77,
+            "features": {
               "extended_multizone": true
             }
-          ],
-          [
-            2,
-            80,
-            {
+          },
+          {
+            "major": 2,
+            "minor": 80,
+            "features": {
               "temperature_range": [
                 1500,
                 9000
               ]
             }
-          ]
+          }
         ]
       },
       {
@@ -336,16 +336,16 @@
           ]
         },
         "upgrades": [
-          [
-            2,
-            80,
-            {
+          {
+            "major": 2,
+            "minor": 80,
+            "features": {
               "temperature_range": [
                 1500,
                 9000
               ]
             }
-          ]
+          }
         ]
       },
       {
@@ -363,16 +363,16 @@
           ]
         },
         "upgrades": [
-          [
-            2,
-            80,
-            {
+          {
+            "major": 2,
+            "minor": 80,
+            "features": {
               "temperature_range": [
                 1500,
                 9000
               ]
             }
-          ]
+          }
         ]
       },
       {
@@ -395,23 +395,23 @@
           ]
         },
         "upgrades": [
-          [
-            2,
-            77,
-            {
+          {
+            "major": 2,
+            "minor": 77,
+            "features": {
               "extended_multizone": true
             }
-          ],
-          [
-            2,
-            80,
-            {
+          },
+          {
+            "major": 2,
+            "minor": 80,
+            "features": {
               "temperature_range": [
                 1500,
                 9000
               ]
             }
-          ]
+          }
         ]
       },
       {
@@ -429,16 +429,16 @@
           ]
         },
         "upgrades": [
-          [
-            2,
-            80,
-            {
+          {
+            "major": 2,
+            "minor": 80,
+            "features": {
               "temperature_range": [
                 1500,
                 9000
               ]
             }
-          ]
+          }
         ]
       },
       {
@@ -456,16 +456,16 @@
           ]
         },
         "upgrades": [
-          [
-            2,
-            80,
-            {
+          {
+            "major": 2,
+            "minor": 80,
+            "features": {
               "temperature_range": [
                 1500,
                 9000
               ]
             }
-          ]
+          }
         ]
       },
       {
@@ -483,16 +483,16 @@
           ]
         },
         "upgrades": [
-          [
-            2,
-            80,
-            {
+          {
+            "major": 2,
+            "minor": 80,
+            "features": {
               "temperature_range": [
                 1500,
                 9000
               ]
             }
-          ]
+          }
         ]
       },
       {
@@ -510,16 +510,16 @@
           ]
         },
         "upgrades": [
-          [
-            2,
-            80,
-            {
+          {
+            "major": 2,
+            "minor": 80,
+            "features": {
               "temperature_range": [
                 1500,
                 9000
               ]
             }
-          ]
+          }
         ]
       },
       {
@@ -537,16 +537,16 @@
           ]
         },
         "upgrades": [
-          [
-            2,
-            80,
-            {
+          {
+            "major": 2,
+            "minor": 80,
+            "features": {
               "temperature_range": [
                 1500,
                 9000
               ]
             }
-          ]
+          }
         ]
       },
       {
@@ -564,16 +564,16 @@
           ]
         },
         "upgrades": [
-          [
-            2,
-            80,
-            {
+          {
+            "major": 2,
+            "minor": 80,
+            "features": {
               "temperature_range": [
                 1500,
                 9000
               ]
             }
-          ]
+          }
         ]
       },
       {
@@ -607,16 +607,16 @@
           ]
         },
         "upgrades": [
-          [
-            3,
-            70,
-            {
+          {
+            "major": 3,
+            "minor": 70,
+            "features": {
               "temperature_range": [
                 1500,
                 9000
               ]
             }
-          ]
+          }
         ]
       },
       {
@@ -730,16 +730,16 @@
           ]
         },
         "upgrades": [
-          [
-            3,
-            70,
-            {
+          {
+            "major": 3,
+            "minor": 70,
+            "features": {
               "temperature_range": [
                 1500,
                 9000
               ]
             }
-          ]
+          }
         ]
       },
       {

--- a/products.json
+++ b/products.json
@@ -2,6 +2,17 @@
   {
     "vid": 1,
     "name": "LIFX",
+    "defaults": {
+      "color": false,
+      "chain": false,
+      "matrix": false,
+      "relays": true,
+      "buttons": true,
+      "infrared": false,
+      "multizone": false,
+      "temperature_range": null,
+      "extended_multizone": false
+    },
     "products": [
       {
         "pid": 1,
@@ -16,7 +27,8 @@
             2500,
             9000
           ]
-        }
+        },
+        "upgrades": []
       },
       {
         "pid": 3,
@@ -31,7 +43,8 @@
             2500,
             9000
           ]
-        }
+        },
+        "upgrades": []
       },
       {
         "pid": 10,
@@ -46,7 +59,8 @@
             2700,
             6500
           ]
-        }
+        },
+        "upgrades": []
       },
       {
         "pid": 11,
@@ -61,7 +75,8 @@
             2700,
             6500
           ]
-        }
+        },
+        "upgrades": []
       },
       {
         "pid": 15,
@@ -76,7 +91,8 @@
             2500,
             9000
           ]
-        }
+        },
+        "upgrades": []
       },
       {
         "pid": 18,
@@ -91,7 +107,8 @@
             2500,
             9000
           ]
-        }
+        },
+        "upgrades": []
       },
       {
         "pid": 19,
@@ -106,7 +123,8 @@
             2500,
             9000
           ]
-        }
+        },
+        "upgrades": []
       },
       {
         "pid": 20,
@@ -121,7 +139,8 @@
             2500,
             9000
           ]
-        }
+        },
+        "upgrades": []
       },
       {
         "pid": 22,
@@ -136,7 +155,8 @@
             2500,
             9000
           ]
-        }
+        },
+        "upgrades": []
       },
       {
         "pid": 27,
@@ -151,7 +171,19 @@
             2500,
             9000
           ]
-        }
+        },
+        "upgrades": [
+          [
+            2,
+            80,
+            {
+              "temperature_range": [
+                1500,
+                9000
+              ]
+            }
+          ]
+        ]
       },
       {
         "pid": 28,
@@ -166,7 +198,19 @@
             2500,
             9000
           ]
-        }
+        },
+        "upgrades": [
+          [
+            2,
+            80,
+            {
+              "temperature_range": [
+                1500,
+                9000
+              ]
+            }
+          ]
+        ]
       },
       {
         "pid": 29,
@@ -181,7 +225,19 @@
             2500,
             9000
           ]
-        }
+        },
+        "upgrades": [
+          [
+            2,
+            80,
+            {
+              "temperature_range": [
+                1500,
+                9000
+              ]
+            }
+          ]
+        ]
       },
       {
         "pid": 30,
@@ -196,7 +252,19 @@
             2500,
             9000
           ]
-        }
+        },
+        "upgrades": [
+          [
+            2,
+            80,
+            {
+              "temperature_range": [
+                1500,
+                9000
+              ]
+            }
+          ]
+        ]
       },
       {
         "pid": 31,
@@ -211,7 +279,8 @@
             2500,
             9000
           ]
-        }
+        },
+        "upgrades": []
       },
       {
         "pid": 32,
@@ -231,7 +300,26 @@
             2,
             77
           ]
-        }
+        },
+        "upgrades": [
+          [
+            2,
+            77,
+            {
+              "extended_multizone": true
+            }
+          ],
+          [
+            2,
+            80,
+            {
+              "temperature_range": [
+                1500,
+                9000
+              ]
+            }
+          ]
+        ]
       },
       {
         "pid": 36,
@@ -246,7 +334,19 @@
             2500,
             9000
           ]
-        }
+        },
+        "upgrades": [
+          [
+            2,
+            80,
+            {
+              "temperature_range": [
+                1500,
+                9000
+              ]
+            }
+          ]
+        ]
       },
       {
         "pid": 37,
@@ -261,7 +361,19 @@
             2500,
             9000
           ]
-        }
+        },
+        "upgrades": [
+          [
+            2,
+            80,
+            {
+              "temperature_range": [
+                1500,
+                9000
+              ]
+            }
+          ]
+        ]
       },
       {
         "pid": 38,
@@ -281,7 +393,26 @@
             2,
             77
           ]
-        }
+        },
+        "upgrades": [
+          [
+            2,
+            77,
+            {
+              "extended_multizone": true
+            }
+          ],
+          [
+            2,
+            80,
+            {
+              "temperature_range": [
+                1500,
+                9000
+              ]
+            }
+          ]
+        ]
       },
       {
         "pid": 39,
@@ -296,7 +427,19 @@
             1500,
             9000
           ]
-        }
+        },
+        "upgrades": [
+          [
+            2,
+            80,
+            {
+              "temperature_range": [
+                1500,
+                9000
+              ]
+            }
+          ]
+        ]
       },
       {
         "pid": 40,
@@ -311,7 +454,19 @@
             2500,
             9000
           ]
-        }
+        },
+        "upgrades": [
+          [
+            2,
+            80,
+            {
+              "temperature_range": [
+                1500,
+                9000
+              ]
+            }
+          ]
+        ]
       },
       {
         "pid": 43,
@@ -326,7 +481,19 @@
             2500,
             9000
           ]
-        }
+        },
+        "upgrades": [
+          [
+            2,
+            80,
+            {
+              "temperature_range": [
+                1500,
+                9000
+              ]
+            }
+          ]
+        ]
       },
       {
         "pid": 44,
@@ -341,7 +508,19 @@
             2500,
             9000
           ]
-        }
+        },
+        "upgrades": [
+          [
+            2,
+            80,
+            {
+              "temperature_range": [
+                1500,
+                9000
+              ]
+            }
+          ]
+        ]
       },
       {
         "pid": 45,
@@ -356,7 +535,19 @@
             2500,
             9000
           ]
-        }
+        },
+        "upgrades": [
+          [
+            2,
+            80,
+            {
+              "temperature_range": [
+                1500,
+                9000
+              ]
+            }
+          ]
+        ]
       },
       {
         "pid": 46,
@@ -371,7 +562,19 @@
             2500,
             9000
           ]
-        }
+        },
+        "upgrades": [
+          [
+            2,
+            80,
+            {
+              "temperature_range": [
+                1500,
+                9000
+              ]
+            }
+          ]
+        ]
       },
       {
         "pid": 49,
@@ -383,10 +586,11 @@
           "infrared": false,
           "multizone": false,
           "temperature_range": [
-            2500,
+            1500,
             9000
           ]
-        }
+        },
+        "upgrades": []
       },
       {
         "pid": 50,
@@ -399,9 +603,21 @@
           "multizone": false,
           "temperature_range": [
             1500,
-            4000
+            6500
           ]
-        }
+        },
+        "upgrades": [
+          [
+            3,
+            70,
+            {
+              "temperature_range": [
+                1500,
+                9000
+              ]
+            }
+          ]
+        ]
       },
       {
         "pid": 51,
@@ -416,7 +632,8 @@
             2700,
             2700
           ]
-        }
+        },
+        "upgrades": []
       },
       {
         "pid": 52,
@@ -428,10 +645,11 @@
           "infrared": false,
           "multizone": false,
           "temperature_range": [
-            2500,
+            1500,
             9000
           ]
-        }
+        },
+        "upgrades": []
       },
       {
         "pid": 53,
@@ -443,10 +661,11 @@
           "infrared": false,
           "multizone": false,
           "temperature_range": [
-            2500,
+            1500,
             9000
           ]
-        }
+        },
+        "upgrades": []
       },
       {
         "pid": 55,
@@ -461,7 +680,8 @@
             2500,
             9000
           ]
-        }
+        },
+        "upgrades": []
       },
       {
         "pid": 57,
@@ -476,7 +696,8 @@
             1500,
             9000
           ]
-        }
+        },
+        "upgrades": []
       },
       {
         "pid": 59,
@@ -488,10 +709,11 @@
           "infrared": false,
           "multizone": false,
           "temperature_range": [
-            2500,
+            1500,
             9000
           ]
-        }
+        },
+        "upgrades": []
       },
       {
         "pid": 60,
@@ -504,9 +726,21 @@
           "multizone": false,
           "temperature_range": [
             1500,
-            4000
+            6500
           ]
-        }
+        },
+        "upgrades": [
+          [
+            3,
+            70,
+            {
+              "temperature_range": [
+                1500,
+                9000
+              ]
+            }
+          ]
+        ]
       },
       {
         "pid": 61,
@@ -521,7 +755,8 @@
             2700,
             2700
           ]
-        }
+        },
+        "upgrades": []
       },
       {
         "pid": 62,
@@ -533,10 +768,11 @@
           "infrared": false,
           "multizone": false,
           "temperature_range": [
-            2500,
+            1500,
             9000
           ]
-        }
+        },
+        "upgrades": []
       },
       {
         "pid": 63,
@@ -548,10 +784,11 @@
           "infrared": false,
           "multizone": false,
           "temperature_range": [
-            2500,
+            1500,
             9000
           ]
-        }
+        },
+        "upgrades": []
       },
       {
         "pid": 64,
@@ -563,10 +800,11 @@
           "infrared": true,
           "multizone": false,
           "temperature_range": [
-            2500,
+            1500,
             9000
           ]
-        }
+        },
+        "upgrades": []
       },
       {
         "pid": 65,
@@ -578,10 +816,11 @@
           "infrared": true,
           "multizone": false,
           "temperature_range": [
-            2500,
+            1500,
             9000
           ]
-        }
+        },
+        "upgrades": []
       },
       {
         "pid": 66,
@@ -596,7 +835,8 @@
             2700,
             2700
           ]
-        }
+        },
+        "upgrades": []
       },
       {
         "pid": 68,
@@ -611,7 +851,8 @@
             1500,
             9000
           ]
-        }
+        },
+        "upgrades": []
       },
       {
         "pid": 70,
@@ -624,7 +865,22 @@
           "buttons": true,
           "infrared": false,
           "multizone": false
-        }
+        },
+        "upgrades": []
+      },
+      {
+        "pid": 71,
+        "name": "LIFX Switch",
+        "features": {
+          "color": false,
+          "relays": true,
+          "chain": false,
+          "matrix": false,
+          "buttons": true,
+          "infrared": false,
+          "multizone": false
+        },
+        "upgrades": []
       },
       {
         "pid": 81,
@@ -639,7 +895,8 @@
             2200,
             6500
           ]
-        }
+        },
+        "upgrades": []
       },
       {
         "pid": 82,
@@ -654,7 +911,8 @@
             2100,
             2100
           ]
-        }
+        },
+        "upgrades": []
       },
       {
         "pid": 85,
@@ -669,7 +927,8 @@
             2000,
             2000
           ]
-        }
+        },
+        "upgrades": []
       },
       {
         "pid": 87,
@@ -684,7 +943,8 @@
             2700,
             2700
           ]
-        }
+        },
+        "upgrades": []
       },
       {
         "pid": 88,
@@ -699,7 +959,8 @@
             2700,
             2700
           ]
-        }
+        },
+        "upgrades": []
       },
       {
         "pid": 89,
@@ -712,7 +973,8 @@
           "buttons": true,
           "infrared": false,
           "multizone": false
-        }
+        },
+        "upgrades": []
       },
       {
         "pid": 90,
@@ -725,10 +987,11 @@
           "infrared": false,
           "multizone": false,
           "temperature_range": [
-            2500,
+            1500,
             9000
           ]
-        }
+        },
+        "upgrades": []
       },
       {
         "pid": 91,
@@ -740,10 +1003,11 @@
           "infrared": false,
           "multizone": false,
           "temperature_range": [
-            2500,
+            1500,
             9000
           ]
-        }
+        },
+        "upgrades": []
       },
       {
         "pid": 92,
@@ -755,10 +1019,11 @@
           "infrared": false,
           "multizone": false,
           "temperature_range": [
-            2500,
+            1500,
             9000
           ]
-        }
+        },
+        "upgrades": []
       },
       {
         "pid": 94,
@@ -770,10 +1035,11 @@
           "infrared": false,
           "multizone": false,
           "temperature_range": [
-            2500,
+            1500,
             9000
           ]
-        }
+        },
+        "upgrades": []
       },
       {
         "pid": 96,
@@ -788,7 +1054,8 @@
             2200,
             6500
           ]
-        }
+        },
+        "upgrades": []
       },
       {
         "pid": 97,
@@ -800,10 +1067,11 @@
           "infrared": false,
           "multizone": false,
           "temperature_range": [
-            2500,
+            1500,
             9000
           ]
-        }
+        },
+        "upgrades": []
       },
       {
         "pid": 98,
@@ -815,10 +1083,11 @@
           "infrared": false,
           "multizone": false,
           "temperature_range": [
-            2500,
+            1500,
             9000
           ]
-        }
+        },
+        "upgrades": []
       },
       {
         "pid": 99,
@@ -831,10 +1100,11 @@
           "infrared": false,
           "multizone": false,
           "temperature_range": [
-            2500,
+            1500,
             9000
           ]
-        }
+        },
+        "upgrades": []
       },
       {
         "pid": 100,
@@ -849,7 +1119,8 @@
             2100,
             2100
           ]
-        }
+        },
+        "upgrades": []
       },
       {
         "pid": 101,
@@ -864,7 +1135,8 @@
             2000,
             2000
           ]
-        }
+        },
+        "upgrades": []
       },
       {
         "pid": 109,
@@ -876,10 +1148,11 @@
           "infrared": true,
           "multizone": false,
           "temperature_range": [
-            2500,
+            1500,
             9000
           ]
-        }
+        },
+        "upgrades": []
       },
       {
         "pid": 110,
@@ -891,10 +1164,11 @@
           "infrared": true,
           "multizone": false,
           "temperature_range": [
-            2500,
+            1500,
             9000
           ]
-        }
+        },
+        "upgrades": []
       },
       {
         "pid": 111,
@@ -906,10 +1180,11 @@
           "infrared": true,
           "multizone": false,
           "temperature_range": [
-            2500,
+            1500,
             9000
           ]
-        }
+        },
+        "upgrades": []
       }
     ]
   }


### PR DESCRIPTION
Correcting some existing kelvin ranges that weren't correct. They were
correct for before old firmware that was released in 2018!

And added the ability to specify new capabilities with new firmware
that's a bit less annoying to use than the min_ext options we use for
extended multizone firmware

Fixes #12 